### PR TITLE
Fix typo in f_nj_style readme

### DIFF
--- a/static/vendor/f_nj_style/readme.txt
+++ b/static/vendor/f_nj_style/readme.txt
@@ -1,1 +1,1 @@
-this sectino is created by foad to replace the twitter icon with google scholar icons
+this section is created by foad to replace the twitter icon with google scholar icons


### PR DESCRIPTION
## Summary
- correct a typo in `readme.txt` for the f_nj_style vendor folder
- ensure file ends with a newline

## Testing
- `od -c static/vendor/f_nj_style/readme.txt`

------
https://chatgpt.com/codex/tasks/task_e_683f48c137d48324a28d7d3c25adc24d