### PR TITLE
Fix README cd path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This repository contains the source code for my [personal portfolio website](HTT
 3. **Set Up the Flask Application:**
    Navigate to your project directory and install dependencies:
    ```bash
-   cd portfolio-website
+   cd personal-porftofilo-web-design
    pip3 install -r requirements.txt
    ```
 4. **Configure Apache to Serve the Flask App:**


### PR DESCRIPTION
## Summary
- fix setup instructions in README

## Testing
- `python3 -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_683f49c5274483248b874167eef50889